### PR TITLE
Includes an auto_branch_prefix property

### DIFF
--- a/git_jira/git_jira.py
+++ b/git_jira/git_jira.py
@@ -28,7 +28,7 @@ def load_branches():
         raise Exception("Please disclose your jira token as $JIRA_PAT")
     req = request.Request(
         instance + '/rest/api/2/search?'
-                   'jql=assignee=currentUser()+order+by+updated&fields=id,key,summary,issuetype,assignee',
+        'jql=assignee=currentUser()+order+by+updated&fields=id,key,summary,issuetype,assignee',
         method="GET")
     req.add_header('Authorization', f'Bearer {token}')
     response = request.urlopen(req).read().decode('utf-8')
@@ -41,7 +41,7 @@ def load_branches():
         formatted_summary = re.sub(r"[^a-zA-Z0-9]+", ' ', formatted)
         formatted_branches.append({
             'summary': formatted_summary,
-            'issuetype': issue['fields']['issuetype']  # Added to retrieve the ticket type
+            'issuetype': issue['fields']['issuetype']
         })
     return formatted_branches[:MAX_RESULT]
 
@@ -56,7 +56,7 @@ def main(prefix: Annotated[str, typer.Option(help="Prefix that is being used for
     --auto_branch_prefix will enable the ticket type to set the prefix: feature, bugfix, or refactor
     """
     tasks = load_branches()
-    formatted_tasks = [f"{task['summary']}" for task in tasks]  # Display only the summary
+    formatted_tasks = [f"{task['summary']}" for task in tasks]
     terminal_menu = TerminalMenu(formatted_tasks)
     menu_entry_index = terminal_menu.show()
     if menu_entry_index is not None:

--- a/git_jira/git_jira.py
+++ b/git_jira/git_jira.py
@@ -15,6 +15,7 @@ MAX_RESULT = 5
 # Mapping of ticket types to branch prefixes
 TICKET_TYPE_TO_PREFIX = {
     "Story": "feature",
+    "Task": "feature",
     "Bug": "bugfix",
     "Refactoring": "refactor"
 }

--- a/git_jira/git_jira.py
+++ b/git_jira/git_jira.py
@@ -12,6 +12,12 @@ from typing import Optional
 
 MAX_RESULT = 5
 
+# Mapping of ticket types to branch prefixes
+TICKET_TYPE_TO_PREFIX = {
+    "Story": "feature",
+    "Bug": "bugfix",
+    "Refactoring": "refactor"
+}
 
 def load_branches():
     instance = os.environ.get("JIRA_INSTANCE")
@@ -22,7 +28,7 @@ def load_branches():
         raise Exception("Please disclose your jira token as $JIRA_PAT")
     req = request.Request(
         instance + '/rest/api/2/search?'
-        'jql=assignee=currentUser()+order+by+updated&fields=id,key,summary,issuetype,assignee',
+                   'jql=assignee=currentUser()+order+by+updated&fields=id,key,summary,issuetype,assignee',
         method="GET")
     req.add_header('Authorization', f'Bearer {token}')
     response = request.urlopen(req).read().decode('utf-8')
@@ -32,28 +38,42 @@ def load_branches():
 
     for issue in response['issues']:
         formatted = issue['key'] + " " + issue['fields']['summary']
-        formatted_branches.append(re.sub(r"[^a-zA-Z0-9]+", ' ', formatted))
+        formatted_summary = re.sub(r"[^a-zA-Z0-9]+", ' ', formatted)
+        formatted_branches.append({
+            'summary': formatted_summary,
+            'issuetype': issue['fields']['issuetype']  # Added to retrieve the ticket type
+        })
     return formatted_branches[:MAX_RESULT]
 
-
 def main(prefix: Annotated[str, typer.Option(help="Prefix that is being used for the new branch.")] = "feature",
-         no_prefix: Annotated[bool, typer.Option("--no-prefix", help="Will not use a prefix")] = False):
+         no_prefix: Annotated[bool, typer.Option("--no-prefix", help="Will not use a prefix")] = False,
+         auto_branch_prefix: Annotated[bool, typer.Option("--auto-branch-prefix", help="Automatically determine branch prefix based on ticket type")] = False):
     """
-   CLI to switch to git branches based on one's JIRA tickets.
+    CLI to switch to git branches based on one's JIRA tickets.
 
-   If --prefix is used, it will add a specific prefix to the branch (e.g. feature -> "feature/")
-   --no-prefix will omit the default "feature/" prefix.
-   """
+    If --prefix is used, it will add a specific prefix to the branch (e.g. feature -> "feature/")
+    --no-prefix will omit the default "feature/" prefix.
+    --auto_branch_prefix will enable the ticket type to set the prefix: feature, bugfix, or refactor
+    """
     tasks = load_branches()
-    terminal_menu = TerminalMenu(tasks)
+    formatted_tasks = [f"{task['summary']}" for task in tasks]  # Display only the summary
+    terminal_menu = TerminalMenu(formatted_tasks)
     menu_entry_index = terminal_menu.show()
-    selected_task = tasks[menu_entry_index]
-    prefix = None if no_prefix else prefix
-    formatted_branch = format_branch(selected_task, prefix)
-    print(f"Switching to branch: {formatted_branch}")
-    process = subprocess.Popen(['git', 'switch', '-c', formatted_branch],
-                               stdout=subprocess.PIPE)
-    process.communicate()
+    if menu_entry_index is not None:
+        selected_task = tasks[menu_entry_index]
+        prefix = None if no_prefix else prefix
+        if auto_branch_prefix:
+            auto_prefix = TICKET_TYPE_TO_PREFIX.get(selected_task['issuetype']['name'], None)
+            print(f"Ticket Type: {selected_task['issuetype']}")
+            formatted_branch = format_branch(selected_task['summary'], auto_prefix)
+        else:
+            formatted_branch = format_branch(selected_task['summary'], prefix)
+        print(f"Switching to branch: {formatted_branch}")
+        process = subprocess.Popen(['git', 'switch', '-c', formatted_branch],
+                                   stdout=subprocess.PIPE)
+        process.communicate()
+    else:
+        print("No menu entry selected. Exiting.")
 
 
 def format_branch(selected_task: str, prefix: Optional[str]):


### PR DESCRIPTION
Identifies the ticket type to create branches with prefixes like `feature`, `bugfix`, or `refactor`
Fixes #1 